### PR TITLE
Let users only be logged in admin portal to use GraphQL endpoint

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -29,12 +29,12 @@ class GraphqlController < ApplicationController
   private
 
   def current_user
-    # look up a User
-    return unless bearer_token
-
-    user_id = User.id_from_token(bearer_token)
-
-    User.find user_id
+    if bearer_token
+      user_id = User.id_from_token(bearer_token)
+      User.find(user_id)
+    else
+      super
+    end
   rescue ActiveSupport::MessageVerifier::InvalidSignature
     nil
   end


### PR DESCRIPTION
BEFORE:

While logged into admin portal and using GraphiQL, it was as if you were not logged in. This was because the GraphqlController would only authenticate against the bearer_token (using headers).

AFTER:

<img width="721" alt="Screen Shot 2021-10-09 at 1 12 56 PM" src="https://user-images.githubusercontent.com/12770108/136668050-47b99778-1675-43aa-99be-f714d45ebfc8.png">

If no `bearer_token` is found, then fallback to Devise's `current_user` implementation.
