### PR TITLE
Add ticket category & set to admin category in admin interface

### DIFF
--- a/app/controllers/admin/tickets_controller.rb
+++ b/app/controllers/admin/tickets_controller.rb
@@ -20,6 +20,7 @@ module Admin
 
     def create
       @ticket = SupportTicket.new(ticket_params)
+      @ticket.category = :admin
 
       if @ticket.valid?
         @ticket.save!

--- a/app/models/support_ticket.rb
+++ b/app/models/support_ticket.rb
@@ -10,9 +10,10 @@ class SupportTicket < ApplicationRecord
   belongs_to :survey_response, foreign_key: :survey_response_id,
                                optional: true
 
-  enum status: {active: 0, closed: 1}
-
   validates :description, presence: true
+
+  enum status: {active: 0, closed: 1}
+  enum category: {survey_response: 0, admin: 1, contact_info: 2}
 
   def close!(closer)
     return false if closed?

--- a/db/migrate/20211016151611_add_category_to_support_tickets.rb
+++ b/db/migrate/20211016151611_add_category_to_support_tickets.rb
@@ -1,0 +1,5 @@
+class AddCategoryToSupportTickets < ActiveRecord::Migration[6.1]
+  def change
+    add_column :support_tickets, :category, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_16_141004) do
+ActiveRecord::Schema.define(version: 2021_10_16_151611) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 2021_10_16_141004) do
     t.bigint "survey_response_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "category", default: 0, null: false
     t.index ["closer_id"], name: "index_support_tickets_on_closer_id"
     t.index ["requestor_id"], name: "index_support_tickets_on_requestor_id"
     t.index ["survey_response_id"], name: "index_support_tickets_on_survey_response_id"

--- a/spec/requests/tickets_spec.rb
+++ b/spec/requests/tickets_spec.rb
@@ -38,10 +38,11 @@ RSpec.describe "/admin/tickets", type: :request do
 
   describe "POST /create" do
     context "with valid parameters" do
-      it "creates a new Support Ticket" do
+      it "creates an admin Support Ticket", :aggregate_failures do
         expect do
           post admin_tickets_path, params: {support_ticket: valid_attributes}
         end.to change(SupportTicket, :count).by(1)
+        expect(SupportTicket.last.category).to eq "admin"
       end
 
       it "redirects to support tickets index" do


### PR DESCRIPTION
Resolves #97 

### Description

Adds category enum to support tickets to track different places they are created from.

### Type of change

* New feature (non-breaking change which adds functionality)
