### PR TITLE
Update meeting_duration specs

### DIFF
--- a/spec/models/meeting_duration_spec.rb
+++ b/spec/models/meeting_duration_spec.rb
@@ -5,7 +5,17 @@ RSpec.describe MeetingDuration, type: :model do
     expect(create(:meeting_duration)).to be_valid
   end
 
-  it "marks status of survey response to upon creation" do
+  context "associations" do
+    it { is_expected.to belong_to(:survey_response) }
+  end
+
+  context "validations" do
+    it { is_expected.to validate_presence_of(:minutes) }
+    it { is_expected.to validate_presence_of(:started_at) }
+    it { is_expected.to validate_presence_of(:survey_response) }
+  end
+
+  it "marks status of survey response to 'complete' upon creation" do
     survey_response = create(:survey_response, status: :incomplete)
 
     create(:meeting_duration, survey_response: survey_response)


### PR DESCRIPTION
Resolves #134

### Description

Added association and validation specs for the meeting_duration model

### Type of change

* New feature (non-breaking change which adds functionality)
