### PR TITLE
[ISSUE-144] sort volunteers by status

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,4 +39,5 @@ group :test do
   gem "standardrb"
   gem "selenium-webdriver", "4.0.0.rc2" # temporarily locking to a beta version until 4.x comes out - to fix docker tests https://github.com/SeleniumHQ/selenium/issues/9001
   gem "shoulda-matchers"
+  gem "stimulus_reflex_testing"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,8 @@ GEM
       rack
       rails (>= 5.2)
       redis
+    stimulus_reflex_testing (0.3.0)
+      stimulus_reflex (>= 3.3.0)
     thor (1.1.0)
     thread-local (1.1.0)
     tilt (2.0.10)
@@ -313,6 +315,7 @@ DEPENDENCIES
   spring
   standardrb
   stimulus_reflex (~> 3.4)
+  stimulus_reflex_testing
   turbolinks (~> 5.2.0)
   tzinfo-data
   webpacker (~> 5.4)

--- a/app/views/admin/volunteers/_volunteers_table.html.erb
+++ b/app/views/admin/volunteers/_volunteers_table.html.erb
@@ -23,7 +23,15 @@
       </th>
       <th scope="col">Email</th>
       <th scope="col">Phone</th>
-      <th scope="col">Status</th>
+
+      <th
+        id="volunteers-status"
+        data-reflex="click->VolunteersTable#sort"
+        data-column="status"
+        data-direction="asc"
+        scope="col"
+        class="hover:cursor-pointer"
+      >Status</th>
       <th class="text-center" scope="col">Actions</th>
     </tr>
   </thead>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "rspec/rails"
 require "capybara/rspec"
 require "devise"
+require "stimulus_reflex_testing/rspec"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |file| require file }
 

--- a/spec/reflex/volunteers_table_reflex_spec.rb
+++ b/spec/reflex/volunteers_table_reflex_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe VolunteersTableReflex, type: :reflex do
+  let(:reflex) { build_reflex(url: admin_volunteers_path) }
+
+  describe "#sort" do
+    before do
+      2.times do
+        create(:volunteer, status: :active)
+        create(:volunteer, status: :inactive)
+      end
+    end
+
+    context "status" do
+      it "sort asc on status" do
+        reflex.element.dataset.column = "status"
+        reflex.element.dataset.direction = "asc"
+
+        reflex.run(:sort)
+
+        morph = reflex.broadcaster.morphs.first
+        expect(morph.first).to eql "#volunteers"
+        expect(morph.second).to eql Admin::VolunteersController.render(:_volunteers_table,
+          layout: false,
+          locals: {volunteers: User.all.order(status: :asc)})
+      end
+
+      it "sorts desc on status" do
+        reflex.element.dataset.column = "status"
+        reflex.element.dataset.direction = "desc"
+
+        reflex.run(:sort)
+
+        morph = reflex.broadcaster.morphs.first
+        expect(morph.first).to eql "#volunteers"
+        expect(morph.second).to eql Admin::VolunteersController.render(:_volunteers_table,
+          layout: false,
+          locals: {volunteers: User.all.order(status: :desc)})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #144 <!--fill issue number-->

<!-- Go through this checklist before opening your PR

### Self Checklist:

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes ("bin/rspec")
- I have run [`standardrb`](https://github.com/testdouble/standard) and verified there are no lint offenses in my code (use `standardrb --fix` to autocorrect offenses)
- I have included "WIP" in the PR Title if this is in progress
- If I have made modifications to Graphql, I have run `rails graphql:schema:dump` to update the schema and IDL with my changes.

-->

### Description

- Now we should be able sort volunteers by status.
- I have introduced [stimulus_reflex_testing](https://github.com/podia/stimulus_reflex_testing) which provides some help to test stimulus reflex. 
- How have you tested this? 
  Manually on the UI.
  Added some specs in this commit https://github.com/rubyforgood/inkind-admin/pull/149/commits/2a99019d895c9b7f10a2c5f9629216503820d6d0
- Anything else we should know about?
  Nothing comes to mind. 

### Type of change

<!-- Which of these options are relevant? Remove those that do not apply. -->

* New feature (non-breaking change which adds functionality)

### Screenshots

![volunteer_status](https://user-images.githubusercontent.com/4189070/142741954-f7593a99-287c-404f-929c-2bf738c1799c.gif)

