### PR TITLE
Add Support Ticket question type

### DIFF
--- a/app/models/survey_support_ticket_question.rb
+++ b/app/models/survey_support_ticket_question.rb
@@ -1,0 +1,10 @@
+class SurveySupportTicketQuestion < SurveyQuestion
+  has_many :options, class_name: "SurveyQuestionOption",
+                     foreign_key: :survey_question_id,
+                     dependent: :destroy
+
+  # SurveySupportTicketQuestions are SingleSelectQuestions that have 2 options: Yes/No
+  # In the survey-taking app, inkind-volunteer, if "Yes" is selected, then a
+  # follow up Support Ticket form is prompted.
+  # If "No" is selected, then no Support Ticket form is prompted.
+end

--- a/db/seeds/survey.rb
+++ b/db/seeds/survey.rb
@@ -58,7 +58,7 @@ SurveyQuestion.create!(
 
 question6 = SurveyQuestion.create!(
   survey: survey,
-  type: "SurveySingleSelectQuestion",
+  type: "SurveySupportTicketQuestion",
   heading: "Question for your:",
   prompt: "Would you like a staff member to contact you?"
 )


### PR DESCRIPTION
Working towards https://github.com/rubyforgood/inkind-volunteer/issues/72 .

### Description

Adds special question_type to let the survey-taker app know that a followup Support Ticket form should be rendered.

### Type of change

* New feature (non-breaking change which adds functionality)
