### PR TITLE
Split Guardian & Emergency Contact name fields on Student #145

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,9 +22,9 @@ group :development, :test do
 end
 
 group :development do
+  gem "foreman"
   gem "listen", "~> 3.3"
   gem "spring"
-  gem "foreman"
 end
 
 group :test do
@@ -32,9 +32,9 @@ group :test do
   gem "capybara-screenshot"
   gem "factory_bot_rails", "~> 6.2"
   gem "rspec-rails", "~> 5.0.0"
-  gem "standardrb"
   gem "selenium-webdriver", "4.0.0.rc2" # temporarily locking to a beta version until 4.x comes out - to fix docker tests https://github.com/SeleniumHQ/selenium/issues/9001
   gem "shoulda-matchers"
+  gem "standardrb"
 end
 
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]

--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -57,8 +57,8 @@ module Admin
 
     def admin_user_params
       params.require(:user)
-        .permit(:first_name, :last_name, :email, :phone_number)
-        .merge(role: :admin)
+            .permit(:first_name, :last_name, :email, :phone_number)
+            .merge(role: :admin)
     end
   end
 end

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -2,7 +2,7 @@ module Admin
   class ApplicationController < ::ApplicationController
     before_action :authenticate_user!, :verify_admin!
 
-    private
+  private
 
     def verify_admin!
       verify_user! "Sorry, only admins can view this page.", &:admin?

--- a/app/controllers/admin/imports_controller.rb
+++ b/app/controllers/admin/imports_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   class ImportsController < ApplicationController
     def volunteers
-      result = import_for(User, {skip_password_validation: true})
+      result = import_for(User, { skip_password_validation: true })
       flash[:alert] = "Imported #{result.count} Volunteers"
       redirect_to admin_volunteers_path
     end
@@ -12,7 +12,7 @@ module Admin
       redirect_to admin_students_path
     end
 
-    private
+  private
 
     def import_for(model, additional_properties = {})
       Importer::Csv.import(file_params[:file].tempfile, model, additional_properties)

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -14,7 +14,7 @@ module Admin
       end
     end
 
-    private
+  private
 
     def organization_params
       params.require(:organization).permit(

--- a/app/controllers/admin/students_controller.rb
+++ b/app/controllers/admin/students_controller.rb
@@ -7,7 +7,8 @@ module Admin
       respond_to do |format|
         format.html
         format.csv do
-          send_data Student.export_to_csv(@students, columns: %w[name guardian_name date_of_birth status]), filename: "students-#{Date.today}.csv"
+          send_data Student.export_to_csv(@students, columns: %w[name guardian_name date_of_birth status]),
+                    filename: "students-#{Date.today}.csv"
         end
       end
     end
@@ -59,10 +60,10 @@ module Admin
 
     def students_params
       params.require(:student).permit(:first_name, :last_name,
-        :email, :phone_number, :guardian_phone_number, :guardian_first_name,
-        :guardian_last_name, :emergency_contact_first_name,
-        :emergency_contact_last_name, :emergency_contact_phone_number,
-        :date_of_birth)
+                                      :email, :phone_number, :guardian_phone_number, :guardian_first_name,
+                                      :guardian_last_name, :emergency_contact_first_name,
+                                      :emergency_contact_last_name, :emergency_contact_phone_number,
+                                      :date_of_birth)
     end
   end
 end

--- a/app/controllers/admin/students_controller.rb
+++ b/app/controllers/admin/students_controller.rb
@@ -59,8 +59,9 @@ module Admin
 
     def students_params
       params.require(:student).permit(:first_name, :last_name,
-        :email, :phone_number, :guardian_phone_number, :guardian_name,
-        :emergency_contact_name, :emergency_contact_phone_number,
+        :email, :phone_number, :guardian_phone_number, :guardian_first_name,
+        :guardian_last_name, :emergency_contact_first_name,
+        :emergency_contact_last_name, :emergency_contact_phone_number,
         :date_of_birth)
     end
   end

--- a/app/controllers/admin/tickets_controller.rb
+++ b/app/controllers/admin/tickets_controller.rb
@@ -10,7 +10,8 @@ module Admin
           columns = %w[requestor.name survey_response.student.name created_at description status]
           headers = ["Requestor", "Student", "Created At", "Description", "Status"]
 
-          send_data SupportTicket.export_to_csv(@tickets, columns: columns, headers: headers), filename: "support-tickets-#{Date.today}.csv"
+          send_data SupportTicket.export_to_csv(@tickets, columns: columns, headers: headers),
+                    filename: "support-tickets-#{Date.today}.csv"
         end
       end
     end

--- a/app/controllers/admin/volunteers_controller.rb
+++ b/app/controllers/admin/volunteers_controller.rb
@@ -8,9 +8,11 @@ module Admin
         format.html
         format.csv do
           columns = %w[name email phone_number status last_seen completed_surveys.count support_tickets.count]
-          headers = ["Name", "Email", "Phone", "Status", "Last Seeen", "Total Surveys Completed", "Total Support Tickets Created"]
+          headers = ["Name", "Email", "Phone", "Status", "Last Seeen", "Total Surveys Completed",
+                     "Total Support Tickets Created"]
 
-          send_data User.export_to_csv(@volunteers, columns: columns, headers: headers), filename: "volunteers-#{Date.today}.csv"
+          send_data User.export_to_csv(@volunteers, columns: columns, headers: headers),
+                    filename: "volunteers-#{Date.today}.csv"
         end
       end
     end
@@ -69,7 +71,7 @@ module Admin
       redirect_to action: :index
     end
 
-    private
+  private
 
     def volunteer_params
       params.require(:user).permit(:first_name, :last_name, :email, :phone_number)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,8 +9,8 @@ class ApplicationController < ActionController::Base
     model.errors.map(&:full_message).join(", ")
   end
 
-  def verify_user!(message, &block)
-    return if block.call(current_user)
+  def verify_user!(message)
+    return if yield(current_user)
 
     flash[:alert] = message
     redirect_to :root

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -11,7 +11,7 @@ class GraphqlController < ApplicationController
     variables = prepare_variables(params[:variables])
     query = params[:query]
     operation_name = params[:operationName]
-    context = {current_user: current_user}
+    context = { current_user: current_user }
     result =
       InkindSchema.execute(
         query,
@@ -26,7 +26,7 @@ class GraphqlController < ApplicationController
     handle_error_in_development(e)
   end
 
-  private
+private
 
   def current_user
     warden.authenticate(:user_token, scope: :graphql) || warden.authenticate
@@ -53,8 +53,8 @@ class GraphqlController < ApplicationController
     logger.error error.backtrace.join("\n")
 
     render json: {
-      errors: [{message: error.message, backtrace: error.backtrace}],
-      data: {}
+      errors: [{ message: error.message, backtrace: error.backtrace }],
+      data: {},
     }, status: :internal_server_error
   end
 end

--- a/app/graphql/mutations/create_survey_question_response.rb
+++ b/app/graphql/mutations/create_survey_question_response.rb
@@ -23,7 +23,7 @@ module Mutations
             survey_question_option_id: option
           )
         end
-        {question_response: question_response}
+        { question_response: question_response }
       end
     end
   end

--- a/app/graphql/mutations/create_survey_response.rb
+++ b/app/graphql/mutations/create_survey_response.rb
@@ -10,7 +10,7 @@ module Mutations
 
     def resolve(survey_id:, user_id:, student_id:)
       response = SurveyResponse.create!(survey_id: survey_id, user_id: user_id, student_id: student_id)
-      {response: response}
+      { response: response }
     end
   end
 end

--- a/app/graphql/mutations/sign_in_user.rb
+++ b/app/graphql/mutations/sign_in_user.rb
@@ -15,7 +15,7 @@ module Mutations
 
       raise GraphQL::ExecutionError, "invalid password for user" unless user.valid_password?(credentials[:password])
 
-      {user: user, token: user.token}
+      { user: user, token: user.token }
     end
   end
 end

--- a/app/graphql/queries/students_query.rb
+++ b/app/graphql/queries/students_query.rb
@@ -9,9 +9,9 @@ module Queries
       end
 
       field :students,
-        [Types::StudentType],
-        null: true,
-        description: "All students associated with signed in volunteer"
+            [Types::StudentType],
+            null: true,
+            description: "All students associated with signed in volunteer"
     end
 
     def student(id:)

--- a/app/graphql/queries/survey_responses_query.rb
+++ b/app/graphql/queries/survey_responses_query.rb
@@ -4,9 +4,9 @@ module Queries
 
     included do
       field :survey_responses,
-        [Types::SurveyResponseType],
-        null: true,
-        description: "All survey_responses associated with signed in volunteer"
+            [Types::SurveyResponseType],
+            null: true,
+            description: "All survey_responses associated with signed in volunteer"
 
       field :student_survey_responses, [Types::SurveyResponseType], null: true do
         description "All survey_responses for a specific student associated with signed in volunteer"

--- a/app/graphql/types/student_type.rb
+++ b/app/graphql/types/student_type.rb
@@ -8,9 +8,11 @@ module Types
     field :initials, String, null: false
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
-    field :guardian_name, String, null: true
+    field :guardian_first_name, String, null: true
+    field :guardian_last_name, String, null: true
     field :guardian_phone_number, String, null: true
-    field :emergency_contact_name, String, null: true
+    field :emergency_contact_first_name, String, null: true
+    field :emergency_contact_last_name, String, null: true
     field :emergency_contact_phone_number, String, null: true
   end
 end

--- a/app/helpers/flash_helper.rb
+++ b/app/helpers/flash_helper.rb
@@ -3,8 +3,8 @@ module FlashHelper
     notice: "alert-info",
     success: "alert-success",
     error: "alert-danger",
-    alert: "alert-warning"
-  }
+    alert: "alert-warning",
+  }.freeze
   def flash_banner(level, message)
     return unless message
 

--- a/app/helpers/title_helper.rb
+++ b/app/helpers/title_helper.rb
@@ -2,7 +2,7 @@ module TitleHelper
   def page_title
     [
       page_header_title,
-      default_title
+      default_title,
     ].compact.join(" | ")
   end
 

--- a/app/models/concerns/export_to_csv.rb
+++ b/app/models/concerns/export_to_csv.rb
@@ -8,10 +8,10 @@ module ExportToCsv
 
         collection.each do |obj|
           csv << if obj.respond_to?(:to_csv)
-            obj.to_csv
-          else
-            columns.map { |column| column.split(".").inject(obj, :try) }
-          end
+                   obj.to_csv
+                 else
+                   columns.map { |column| column.split(".").inject(obj, :try) }
+                 end
         end
       end
     end

--- a/app/models/meeting_duration.rb
+++ b/app/models/meeting_duration.rb
@@ -5,7 +5,7 @@ class MeetingDuration < ApplicationRecord
 
   after_create :complete_response
 
-  private
+private
 
   def complete_response
     survey_response.complete!

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -8,7 +8,7 @@ class Student < ApplicationRecord
 
   validates :first_name, :last_name, presence: true
 
-  enum status: {active: 0, inactive: 1}
+  enum status: { active: 0, inactive: 1 }
 
   def name
     "#{first_name} #{last_name}"

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -29,4 +29,12 @@ class Student < ApplicationRecord
     self.status = :active
     save!
   end
+
+  def guardian_full_name
+    "#{guardian_first_name} #{guardian_last_name}"
+  end
+
+  def emergency_contact_full_name
+    "#{emergency_contact_first_name} #{emergency_contact_last_name}"
+  end
 end

--- a/app/models/support_ticket.rb
+++ b/app/models/support_ticket.rb
@@ -12,8 +12,8 @@ class SupportTicket < ApplicationRecord
 
   validates :description, presence: true
 
-  enum status: {active: 0, closed: 1}
-  enum category: {survey_response: 0, admin: 1, contact_info: 2}
+  enum status: { active: 0, closed: 1 }
+  enum category: { survey_response: 0, admin: 1, contact_info: 2 }
 
   def close!(closer)
     return false if closed?

--- a/app/models/survey_response.rb
+++ b/app/models/survey_response.rb
@@ -8,5 +8,5 @@ class SurveyResponse < ApplicationRecord
 
   validates :volunteer, :student, :survey, presence: true
 
-  enum status: {incomplete: 0, complete: 1}
+  enum status: { incomplete: 0, complete: 1 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   attr_accessor :skip_password_validation
 
   devise :database_authenticatable, :registerable, :validatable,
-    :password_expirable, :recoverable, :rememberable
+         :password_expirable, :recoverable, :rememberable
 
   has_many :students_users
   has_many :students, through: :students_users
@@ -14,8 +14,8 @@ class User < ApplicationRecord
 
   validates :first_name, :last_name, presence: true
 
-  enum status: {active: 0, inactive: 1}
-  enum role: {volunteer: 0, admin: 1}
+  enum status: { active: 0, inactive: 1 }
+  enum role: { volunteer: 0, admin: 1 }
 
   def active_for_authentication?
     super && active?
@@ -31,6 +31,7 @@ class User < ApplicationRecord
 
   def password_required?
     return false if skip_password_validation
+
     super
   end
 

--- a/app/reflexes/volunteers_table_reflex.rb
+++ b/app/reflexes/volunteers_table_reflex.rb
@@ -34,13 +34,13 @@ class VolunteersTableReflex < ApplicationReflex
 
   def sort
     volunteers = User.where(role: :volunteer).order("#{element.dataset.column} #{element.dataset.direction}")
-    morph "#volunteers", render(partial: "volunteers_table", locals: {volunteers: volunteers})
+    morph "#volunteers", render(partial: "volunteers_table", locals: { volunteers: volunteers })
 
     set_sort_direction if next_direction(element.dataset.direction) == "desc"
     insert_indicator
   end
 
-  private
+private
 
   def next_direction(direction)
     direction == "asc" ? "desc" : "asc"
@@ -61,7 +61,7 @@ class VolunteersTableReflex < ApplicationReflex
         selector: "##{element.id}",
         html: render(
           partial: "admin/volunteers/sort_indicator",
-          locals: {direction: element.dataset.direction}
+          locals: { direction: element.dataset.direction }
         )
       )
   end

--- a/app/views/admin/students/_form.html.erb
+++ b/app/views/admin/students/_form.html.erb
@@ -15,7 +15,7 @@
 
   <div class="row pr-3 pb-4">
     <div class="col-4">
-      <%= form.text_field :email, class: "form-control", placeholder: "Email" %>
+      <%= form.text_field :date_of_birth, class: "form-control", placeholder: "Date of Birth" %>
     </div>
   </div>
 
@@ -27,7 +27,19 @@
 
   <div class="row pr-3 pb-4">
     <div class="col-4">
-      <%= form.text_field :guardian_name, class: "form-control", placeholder: "Guardian Name" %>
+      <%= form.text_field :email, class: "form-control", placeholder: "Email" %>
+    </div>
+  </div>
+
+  <div class="row pr-3 pb-4">
+    <div class="col-4">
+      <%= form.text_field :guardian_first_name, class: "form-control", placeholder: "Guardian First Name" %>
+    </div>
+  </div>
+
+  <div class="row pr-3 pb-4">
+    <div class="col-4">
+      <%= form.text_field :guardian_last_name, class: "form-control", placeholder: "Guardian Last Name" %>
     </div>
   </div>
 
@@ -39,7 +51,13 @@
 
   <div class="row pr-3 pb-4">
     <div class="col-4">
-      <%= form.text_field :emergency_contact_name, class: "form-control", placeholder: "Emergency Contact Name" %>
+      <%= form.text_field :emergency_contact_first_name, class: "form-control", placeholder: "Emergency Contact First Name" %>
+    </div>
+  </div>
+
+  <div class="row pr-3 pb-4">
+    <div class="col-4">
+      <%= form.text_field :emergency_contact_last_name, class: "form-control", placeholder: "Emergency Contact Last Name" %>
     </div>
   </div>
 
@@ -49,11 +67,6 @@
     </div>
   </div>
 
-  <div class="row pr-3 pb-4">
-    <div class="col-4">
-      <%= form.text_field :date_of_birth, class: "form-control", placeholder: "Date of Birth" %>
-    </div>
-  </div>
 
   <div class="row pr-3 pb-4">
     <div class="col-1">

--- a/app/views/admin/students/index.html.erb
+++ b/app/views/admin/students/index.html.erb
@@ -22,7 +22,7 @@
   <thead>
     <tr>
       <th scope="col">Name</th>
-      <th scope="col">Guardian name</th>
+      <th scope="col">Guardian Full Name</th>
       <th scope="col">DOB</th>
       <th scope="col">Status</th>
       <th class="text-center" scope="col">Actions</th>
@@ -35,7 +35,7 @@
           <%= student.name %>
         </td>
         <td>
-          <%= student.guardian_name %>
+          <%= student.guardian_full_name %>
         </td>
         <td>
           <%= student.date_of_birth %>
@@ -70,4 +70,3 @@
       <li>Save the file as a CSV file.</li>
     </ul>
 <% end %>
-

--- a/db/migrate/20210925152907_create_survey_question_option_responses.rb
+++ b/db/migrate/20210925152907_create_survey_question_option_responses.rb
@@ -4,12 +4,12 @@ class CreateSurveyQuestionOptionResponses < ActiveRecord::Migration[6.1]
       t.references :survey_question_option, null: false,
                                             foriegn_key: true,
                                             index: {
-                                              name: "index_question_option_responses_on_question_option"
+                                              name: "index_question_option_responses_on_question_option",
                                             }
       t.references :survey_question_response, null: false,
                                               foriegn_key: true,
                                               index: {
-                                                name: "index_question_option_responses_on_question_response"
+                                                name: "index_question_option_responses_on_question_response",
                                               }
 
       t.timestamps

--- a/db/migrate/20211128183121_remove_guardian_name_from_students.rb
+++ b/db/migrate/20211128183121_remove_guardian_name_from_students.rb
@@ -1,0 +1,5 @@
+class RemoveGuardianNameFromStudents < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :students, :guardian_name, :string
+  end
+end

--- a/db/migrate/20211128183320_remove_emergency_contact_name_from_students.rb
+++ b/db/migrate/20211128183320_remove_emergency_contact_name_from_students.rb
@@ -1,0 +1,5 @@
+class RemoveEmergencyContactNameFromStudents < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :students, :emergency_contact_name, :string
+  end
+end

--- a/db/migrate/20211128183622_add_guardian_first_name_to_students.rb
+++ b/db/migrate/20211128183622_add_guardian_first_name_to_students.rb
@@ -1,0 +1,5 @@
+class AddGuardianFirstNameToStudents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :students, :guardian_first_name, :string
+  end
+end

--- a/db/migrate/20211128183643_add_guardian_last_name_to_students.rb
+++ b/db/migrate/20211128183643_add_guardian_last_name_to_students.rb
@@ -1,0 +1,5 @@
+class AddGuardianLastNameToStudents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :students, :guardian_last_name, :string
+  end
+end

--- a/db/migrate/20211128183805_add_emergency_contact_first_name_to_students.rb
+++ b/db/migrate/20211128183805_add_emergency_contact_first_name_to_students.rb
@@ -1,0 +1,5 @@
+class AddEmergencyContactFirstNameToStudents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :students, :emergency_contact_first_name, :string
+  end
+end

--- a/db/migrate/20211128183824_add_emergency_contact_last_name_to_students.rb
+++ b/db/migrate/20211128183824_add_emergency_contact_last_name_to_students.rb
@@ -1,0 +1,5 @@
+class AddEmergencyContactLastNameToStudents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :students, :emergency_contact_last_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_16_151611) do
+ActiveRecord::Schema.define(version: 2021_11_28_183824) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,15 +43,17 @@ ActiveRecord::Schema.define(version: 2021_10_16_151611) do
     t.string "email"
     t.string "phone_number"
     t.integer "status", default: 0, null: false
-    t.string "guardian_name"
     t.string "guardian_phone_number"
-    t.string "emergency_contact_name"
     t.string "emergency_contact_phone_number"
     t.date "date_of_birth"
     t.datetime "deactivated_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "deactivator_id"
+    t.string "guardian_first_name"
+    t.string "guardian_last_name"
+    t.string "emergency_contact_first_name"
+    t.string "emergency_contact_last_name"
     t.index ["deactivator_id"], name: "index_students_on_deactivator_id"
   end
 

--- a/db/seeds/students.rb
+++ b/db/seeds/students.rb
@@ -11,9 +11,11 @@ User
           email: Faker::Internet.email,
           date_of_birth: Faker::Date.between(from: 18.years.ago, to: 5.years.ago),
           phone_number: Faker::PhoneNumber.phone_number,
-          guardian_name: Faker::Name.name,
+          guardian_first_name: Faker::Name.gender_neutral_first_name,
+          guardian_last_name: Faker::Name.last_name,
           guardian_phone_number: Faker::PhoneNumber.phone_number,
-          emergency_contact_name: Faker::Name.name,
+          emergency_contact_first_name: Faker::Name.gender_neutral_first_name,
+          emergency_contact_last_name: Faker::Name.last_name,
           emergency_contact_phone_number: Faker::PhoneNumber.phone_number,
           users: [user]
         )

--- a/lib/volunteer_app.rb
+++ b/lib/volunteer_app.rb
@@ -1,9 +1,9 @@
 module VolunteerApp
-  module_function
+module_function
 
   def magic_link(user)
     uri = URI(Rails.application.config.volunteer_app_url)
-    uri.query = "token=" + CGI.escape(user.token)
+    uri.query = "token=#{CGI.escape(user.token)}"
     uri.to_s
   end
 end

--- a/logfile
+++ b/logfile
@@ -1,0 +1,11 @@
+2021-10-27 08:31:16.306 EDT [38193] LOG:  starting PostgreSQL 14.0 on x86_64-apple-darwin20.6.0, compiled by Apple clang version 13.0.0 (clang-1300.0.29.3), 64-bit
+2021-10-27 08:31:16.307 EDT [38193] LOG:  listening on IPv6 address "::1", port 5432
+2021-10-27 08:31:16.307 EDT [38193] LOG:  listening on IPv4 address "127.0.0.1", port 5432
+2021-10-27 08:31:16.308 EDT [38193] LOG:  listening on Unix socket "/tmp/.s.PGSQL.5432"
+2021-10-27 08:31:16.316 EDT [38194] LOG:  database system was shut down at 2021-10-11 14:02:27 EDT
+2021-10-27 08:31:16.321 EDT [38193] LOG:  database system is ready to accept connections
+2021-11-01 11:53:41.637 EDT [46780] FATAL:  database "casa_development" does not exist
+2021-11-23 10:42:29.743 EST [38193] LOG:  received smart shutdown request
+2021-11-23 10:42:29.745 EST [38193] LOG:  background worker "logical replication launcher" (PID 38200) exited with exit code 1
+2021-11-23 10:42:29.745 EST [38195] LOG:  shutting down
+2021-11-23 10:42:29.755 EST [38193] LOG:  database system is shut down

--- a/spec/fixtures/students-with-errors.csv
+++ b/spec/fixtures/students-with-errors.csv
@@ -1,4 +1,4 @@
-first_name,last_name,date_of_birth,email,phone_number,guardian_name,guardian_phone_number,emergency_contact_name,emergency_contact_phone_number
+first_name,last_name,date_of_birth,email,phone_number,_name,guardian_phone_number,emergency_contact_name,emergency_contact_phone_number
 John,Doe1,2006-01-01,email1@example.com,123-456-7890,Mary Doe1,123-456-7891,Jane Smith1,123-456-7892
 ,Doe2,2007-01-01,email2@example.com,231-456-7890,Mary Doe2,231-456-7891,Jane Smith2,123-456-7892
 ,Doe3,2008-01-01,email3@example.com,321-456-7890,Mary Doe3,321-456-7891,Jane Smith3,123-456-7892

--- a/spec/fixtures/students.csv
+++ b/spec/fixtures/students.csv
@@ -1,4 +1,4 @@
-first_name,last_name,date_of_birth,email,phone_number,guardian_name,guardian_phone_number,emergency_contact_name,emergency_contact_phone_number
+first_name,last_name,date_of_birth,email,phone_number,guardian_name,_phone_number,emergency_contact_name,emergency_contact_phone_number
 John,Doe1,2006-01-01,email1@example.com,123-456-7890,Mary Doe1,123-456-7891,Jane Smith1,123-456-7892
 John,Doe2,2007-01-01,email2@example.com,231-456-7890,Mary Doe2,231-456-7891,Jane Smith2,123-456-7892
 John,Doe3,2008-01-01,email3@example.com,321-456-7890,Mary Doe3,321-456-7891,Jane Smith3,123-456-7892


### PR DESCRIPTION
Resolves #145 

### Description
This change replace the guardian_name and emergency_contact_name field on the student table to  guardian_first_name, guardian_last_name, emergency_contact_first_name, & emergency_contact_last_name.
Specified name fields are removed and replaced with first/last name fields -DONE
Update the seed files to still create valid students-DONE
Update the Students index so it doesn't break-DONE
Update the Student form to accept inputs for these fields-DONE.
I've also updated the GraphQl Student Type to reflect the changes above.

### Type of change
Change and add column to student table

### Screenshots
<img width="1617" alt="INKIND" src="https://user-images.githubusercontent.com/82796889/143782934-a0e2081b-a183-478c-a6a2-10e5c7737fdf.png">


