### PR TITLE
Split Guardian & Emergency Contact name fields on Student #145

### DIFF
--- a/app/controllers/admin/students_controller.rb
+++ b/app/controllers/admin/students_controller.rb
@@ -7,7 +7,7 @@ module Admin
       respond_to do |format|
         format.html
         format.csv do
-          send_data Student.export_to_csv(@students, columns: %w[name guardian_name date_of_birth status]), filename: "students-#{Date.today}.csv"
+          send_data Student.export_to_csv(@students, columns: %w[name guardian_last_name date_of_birth status]), filename: "students-#{Date.today}.csv"
         end
       end
     end
@@ -64,9 +64,9 @@ module Admin
 
     def students_params
       params.require(:student).permit(:first_name, :last_name,
-        :email, :phone_number, :guardian_phone_number, :guardian_name,
-        :emergency_contact_name, :emergency_contact_phone_number,
-        :date_of_birth)
+        :email, :phone_number, :guardian_phone_number, :guardian_first_name,
+        :guardian_last_name, :emergency_contact_first_name, :emergency_contact_last_name,
+        :emergency_contact_phone_number, :date_of_birth)
     end
   end
 end

--- a/app/graphql/types/student_type.rb
+++ b/app/graphql/types/student_type.rb
@@ -8,9 +8,20 @@ module Types
     field :initials, String, null: false
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :guardian_first_name, String, null: true
+    field :guardian_last_name, String, null: true
     field :guardian_name, String, null: true
+    def guardian_name
+      # object.guardian_full_name
+      # binding.pry
+    end
     field :guardian_phone_number, String, null: true
+    field :emergency_contact_first_name, String, null: true
+    field :emergency_contact_last_name, String, null: true
     field :emergency_contact_name, String, null: true
+    def emergency_contact_name
+      # object.emergency_contact_full_name
+    end
     field :emergency_contact_phone_number, String, null: true
   end
 end

--- a/app/graphql/types/student_type.rb
+++ b/app/graphql/types/student_type.rb
@@ -22,7 +22,7 @@ module Types
     end
 
     def emergency_contact_name
-     "#{object.emergency_contact_full_name} #{object.emergency_contact_full_name}"
+      "#{object.emergency_contact_full_name} #{object.emergency_contact_full_name}"
     end
   end
 end

--- a/app/graphql/types/student_type.rb
+++ b/app/graphql/types/student_type.rb
@@ -11,16 +11,19 @@ module Types
     field :guardian_first_name, String, null: true
     field :guardian_last_name, String, null: true
     field :guardian_name, String, null: true
-    def guardian_name
-      object.guardian_full_name
-    end
     field :guardian_phone_number, String, null: true
     field :emergency_contact_first_name, String, null: true
     field :emergency_contact_last_name, String, null: true
     field :emergency_contact_name, String, null: true
-    def emergency_contact_name
-      object.emergency_contact_full_name
-    end
     field :emergency_contact_phone_number, String, null: true
+
+    def emergency_contact_name
+      object.student.emergency_contact_first_name_with_emergency_contact_last_name
+    end
+
+    def guardian_name
+      object.student.guardian_first_name_with_guardian_last_name
+    end
   end
+
 end

--- a/app/graphql/types/student_type.rb
+++ b/app/graphql/types/student_type.rb
@@ -12,15 +12,14 @@ module Types
     field :guardian_last_name, String, null: true
     field :guardian_name, String, null: true
     def guardian_name
-      # object.guardian_full_name
-      # binding.pry
+      object.guardian_full_name
     end
     field :guardian_phone_number, String, null: true
     field :emergency_contact_first_name, String, null: true
     field :emergency_contact_last_name, String, null: true
     field :emergency_contact_name, String, null: true
     def emergency_contact_name
-      # object.emergency_contact_full_name
+      object.emergency_contact_full_name
     end
     field :emergency_contact_phone_number, String, null: true
   end

--- a/app/graphql/types/student_type.rb
+++ b/app/graphql/types/student_type.rb
@@ -17,13 +17,12 @@ module Types
     field :emergency_contact_name, String, null: true
     field :emergency_contact_phone_number, String, null: true
 
-    def emergency_contact_name
-      object.student.emergency_contact_first_name_with_emergency_contact_last_name
+    def guardian_name
+      "#{object.guardian_first_name} #{object.guardian_last_name}"
     end
 
-    def guardian_name
-      object.student.guardian_first_name_with_guardian_last_name
+    def emergency_contact_name
+     "#{object.emergency_contact_full_name} #{object.emergency_contact_full_name}"
     end
   end
-
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -43,7 +43,6 @@ class Student < ApplicationRecord
     save!
   end
 
-
   private
 
   def update_volunteer_assignments(volunteer_ids: [])

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -43,6 +43,14 @@ class Student < ApplicationRecord
     save!
   end
 
+  def guardian_full_name
+    "#{guardian_first_name} #{guardian_last_name}"
+  end
+
+  def emergency_contact_full_name
+    "#{emergnecy_contact_first_name} #{emergency_conatct_last_name}"
+  end
+
   private
 
   def update_volunteer_assignment(volunteer_id)

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -43,13 +43,6 @@ class Student < ApplicationRecord
     save!
   end
 
-  def guardian_full_name
-    "#{guardian_first_name} #{guardian_last_name}"
-  end
-
-  def emergency_contact_full_name
-    "#{emergnecy_contact_first_name} #{emergency_conatct_last_name}"
-  end
 
   private
 

--- a/app/reflexes/students_table_reflex.rb
+++ b/app/reflexes/students_table_reflex.rb
@@ -6,6 +6,6 @@ class StudentsTableReflex < ApplicationReflex
   def sort
     sort_records(records: Student.all,
       partial: "students_table",
-      sort_columns: %w[first_name last_name guardian_name status])
+      sort_columns: %w[first_name last_name guardian_last_name status])
   end
 end

--- a/app/views/admin/students/_form.html.erb
+++ b/app/views/admin/students/_form.html.erb
@@ -28,8 +28,12 @@
   </div>
 
   <div class="row pr-3 pb-4">
-    <div class="col-6">
-      <%= form.text_field :guardian_name, class: "form-control", placeholder: "Guardian Name" %>
+    <div class="col-3">
+      <%= form.text_field :guardian_first_name, class: "form-control", placeholder: "Guardian First Name" %>
+    </div>
+
+    <div class="col-3">
+      <%= form.text_field :guardian_last_name, class: "form-control", placeholder: "Guardian Last Name" %>
     </div>
   </div>
 
@@ -40,8 +44,12 @@
   </div>
 
   <div class="row pr-3 pb-4">
-    <div class="col-6">
-      <%= form.text_field :emergency_contact_name, class: "form-control", placeholder: "Emergency Contact Name" %>
+    <div class="col-3">
+      <%= form.text_field :emergency_contact_first_name, class: "form-control", placeholder: "Emergency Contact First Name" %>
+    </div>
+
+    <div class="col-3">
+      <%= form.text_field :emergency_contact_last_name, class: "form-control", placeholder: "Emergency Contact Last Name" %>
     </div>
   </div>
 

--- a/app/views/admin/students/_students_table.html.erb
+++ b/app/views/admin/students/_students_table.html.erb
@@ -33,7 +33,7 @@
           <%= student.name %>
         </td>
         <td>
-          <%= student.guardian_name %>
+          <%= student.guardian_last_name %>
         </td>
         <td>
           <%= student.date_of_birth.strftime('%m/%d/%Y') %>

--- a/db/migrate/20211205210006_remove_guardian_name_and_emergency_contact_name_from_students.rb
+++ b/db/migrate/20211205210006_remove_guardian_name_and_emergency_contact_name_from_students.rb
@@ -1,0 +1,5 @@
+class RemoveGuardianNameAndEmergencyContactNameFromStudents < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :students, :guardian_name, :emergency_contact_name
+  end
+end

--- a/db/migrate/20211205210006_remove_guardian_name_and_emergency_contact_name_from_students.rb
+++ b/db/migrate/20211205210006_remove_guardian_name_and_emergency_contact_name_from_students.rb
@@ -1,5 +1,6 @@
 class RemoveGuardianNameAndEmergencyContactNameFromStudents < ActiveRecord::Migration[6.1]
   def change
-    remove_column :students, :guardian_name, :emergency_contact_name
+    remove_column :students, :guardian_name, :string
+    remove_column :students, :emergency_contact_name, :string
   end
 end

--- a/db/migrate/20211205210424_add_guardian_and_emergency_contact_first_and_last_name_to_students.rb
+++ b/db/migrate/20211205210424_add_guardian_and_emergency_contact_first_and_last_name_to_students.rb
@@ -1,0 +1,8 @@
+class AddGuardianAndEmergencyContactFirstAndLastNameToStudents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :students, :guardian_first_name, :string
+    add_column :students, :guardian_last_name, :string
+    add_column :students, :emergency_contact_first_name, :string
+    add_column :students, :emergency_contact_last_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_20_165531) do
+ActiveRecord::Schema.define(version: 2021_12_05_210424) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -65,7 +65,6 @@ ActiveRecord::Schema.define(version: 2021_11_20_165531) do
     t.string "email"
     t.string "phone_number"
     t.integer "status", default: 0, null: false
-    t.string "guardian_name"
     t.string "guardian_phone_number"
     t.string "emergency_contact_name"
     t.string "emergency_contact_phone_number"
@@ -74,6 +73,10 @@ ActiveRecord::Schema.define(version: 2021_11_20_165531) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "deactivator_id"
+    t.string "guardian_first_name"
+    t.string "guardian_last_name"
+    t.string "emergency_contact_first_name"
+    t.string "emergency_contact_last_name"
     t.index ["deactivator_id"], name: "index_students_on_deactivator_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -66,7 +66,6 @@ ActiveRecord::Schema.define(version: 2021_12_05_210424) do
     t.string "phone_number"
     t.integer "status", default: 0, null: false
     t.string "guardian_phone_number"
-    t.string "emergency_contact_name"
     t.string "emergency_contact_phone_number"
     t.date "date_of_birth"
     t.datetime "deactivated_at"

--- a/db/seeds/students.rb
+++ b/db/seeds/students.rb
@@ -13,9 +13,11 @@ User
           email: Faker::Internet.email,
           date_of_birth: Faker::Date.between(from: 18.years.ago, to: 5.years.ago),
           phone_number: Faker::PhoneNumber.phone_number,
-          guardian_name: Faker::Name.name,
+          guardian_first_name: Faker::Name.gender_neutral_first_name,
+          guardian_last_name: Faker::Name.last_name,
           guardian_phone_number: Faker::PhoneNumber.phone_number,
-          emergency_contact_name: Faker::Name.name,
+          emergency_contact_first_name: Faker::Name.gender_neutral_first_name,
+          emergency_contact_last_name: Faker::Name.last_name,
           emergency_contact_phone_number: Faker::PhoneNumber.phone_number
         )
 

--- a/export/graphql/schema.graphql
+++ b/export/graphql/schema.graphql
@@ -100,8 +100,12 @@ type Student {
   createdAt: ISO8601DateTime!
   dateOfBirth: ISO8601DateTime
   email: String
+  emergencyContactFirstName: String
+  emergencyContactLastName: String
   emergencyContactName: String
   emergencyContactPhoneNumber: String
+  guardianFirstName: String
+  guardianLastName: String
   guardianName: String
   guardianPhoneNumber: String
   id: ID!

--- a/export/graphql/schema.json
+++ b/export/graphql/schema.json
@@ -1004,6 +1004,34 @@
               "deprecationReason": null
             },
             {
+              "name": "emergencyContactFirstName",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "emergencyContactLastName",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "emergencyContactName",
               "description": null,
               "args": [
@@ -1019,6 +1047,34 @@
             },
             {
               "name": "emergencyContactPhoneNumber",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "guardianFirstName",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "guardianLastName",
               "description": null,
               "args": [
 

--- a/spec/fixtures/students-with-errors.csv
+++ b/spec/fixtures/students-with-errors.csv
@@ -1,4 +1,4 @@
-first_name,last_name,date_of_birth,email,phone_number,guardian_name,guardian_phone_number,emergency_contact_name,emergency_contact_phone_number
-John,Doe1,2006-01-01,email1@example.com,123-456-7890,Mary Doe1,123-456-7891,Jane Smith1,123-456-7892
-,Doe2,2007-01-01,email2@example.com,231-456-7890,Mary Doe2,231-456-7891,Jane Smith2,123-456-7892
-,Doe3,2008-01-01,email3@example.com,321-456-7890,Mary Doe3,321-456-7891,Jane Smith3,123-456-7892
+first_name,last_name,date_of_birth,email,phone_number,guardian_first_name,guardian_last_name,guardian_phone_number,emergency_contact_first_name,emergency_contact_last_name,emergency_contact_phone_number
+John,Doe1,2006-01-01,email1@example.com,123-456-7890,Mary,Doe1,123-456-7891,Jane,Smith1,123-456-7892
+,Doe2,2007-01-01,email2@example.com,231-456-7890,Mary,Doe2,231-456-7891,Jane,Smith2,123-456-7892
+,Doe3,2008-01-01,email3@example.com,321-456-7890,Mary,Doe3,321-456-7891,Jane,Smith3,123-456-7892

--- a/spec/fixtures/students.csv
+++ b/spec/fixtures/students.csv
@@ -1,4 +1,4 @@
-first_name,last_name,date_of_birth,email,phone_number,guardian_name,guardian_phone_number,emergency_contact_name,emergency_contact_phone_number
-John,Doe1,2006-01-01,email1@example.com,123-456-7890,Mary Doe1,123-456-7891,Jane Smith1,123-456-7892
-John,Doe2,2007-01-01,email2@example.com,231-456-7890,Mary Doe2,231-456-7891,Jane Smith2,123-456-7892
-John,Doe3,2008-01-01,email3@example.com,321-456-7890,Mary Doe3,321-456-7891,Jane Smith3,123-456-7892
+first_name,last_name,date_of_birth,email,phone_number,guardian_first_name,guardian_last_name,guardian_phone_number,emergency_contact_first_name,emergency_contact_last_name,emergency_contact_phone_number
+John,Doe1,2006-01-01,email1@example.com,123-456-7890,Mary,Doe1,123-456-7891,Jane,Smith1,123-456-7892
+John,Doe2,2007-01-01,email2@example.com,231-456-7890,Mary,Doe2,231-456-7891,Jane,Smith2,123-456-7892
+John,Doe3,2008-01-01,email3@example.com,321-456-7890,Mary,Doe3,321-456-7891,Jane,Smith3,123-456-7892

--- a/spec/reflex/students_table_reflex_spec.rb
+++ b/spec/reflex/students_table_reflex_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe StudentsTableReflex, type: :reflex do
 
     it_behaves_like "sortable table", "first_name", Student.all, "admin/students/_students_table"
     it_behaves_like "sortable table", "last_name", Student.all, "admin/students/_students_table"
-    it_behaves_like "sortable table", "guardian_name", Student.all, "admin/students/_students_table"
+    it_behaves_like "sortable table", "guardian_last_name", Student.all, "admin/students/_students_table"
     it_behaves_like "sortable table", "status", Student.all, "admin/students/_students_table"
   end
 end

--- a/spec/requests/students_spec.rb
+++ b/spec/requests/students_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "/admin/students", type: :request do
           expect(response.header["Content-Type"]).to include "text/csv"
           expect(response.headers["Content-Disposition"]).to include "attachment; filename=\"students-2021-10-14.csv\""
           expect(response.body).to eq <<~CSV
-            "name","guardian_name","date_of_birth","status"
+            "name","guardian_last_name","date_of_birth","status"
             "Campbell McClure","","2010-08-06","active"
             "Indigo Torp","","2012-07-07","inactive"
           CSV


### PR DESCRIPTION
Resolves #145

This change replace the guardian_name and emergency_contact_name field on the student table to guardian_first_name, guardian_last_name, emergency_contact_first_name, & emergency_contact_last_name.
Specified name fields are removed and replaced with first/last name fields -DONE
Update the seed files to still create valid students-DONE
Update the Students index so it doesn't break-DONE
Update the Student form to accept inputs for these fields-DONE.
I've also updated the GraphQl Student Type to reflect the changes above.
Run standardrb --fix -DONE

STUDENT INDEX PAGE
<img width="1728" alt="Screenshot_12_7_21__12_11_PM" src="https://user-images.githubusercontent.com/82796889/145074984-a2895eb9-ad22-4b42-9545-17d4d5137c29.png">
:

STUDENT FORM:
<img width="1302" alt="Screenshot_12_7_21__12_13_PM" src="https://user-images.githubusercontent.com/82796889/145075203-657a5628-416e-40cf-9c1a-650bf8cc15ae.png">
 
