### PR TITLE
Adds City & State to Students

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby "3.0.2"
 
 gem "bootsnap", ">= 1.4.4", require: false
+gem "carmen", "1.1.2"
 gem "devise"
 gem "devise-security", "~> 0.16.0"
 gem "faker", "~> 2.17"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,8 @@ GEM
     capybara-screenshot (1.0.25)
       capybara (>= 1.0, < 4)
       launchy
+    carmen (1.1.2)
+      activesupport (>= 3.0.0)
     childprocess (4.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
@@ -294,6 +296,7 @@ DEPENDENCIES
   byebug
   capybara
   capybara-screenshot
+  carmen (= 1.1.2)
   devise
   devise-security (~> 0.16.0)
   factory_bot_rails (~> 6.2)

--- a/app/controllers/admin/students_controller.rb
+++ b/app/controllers/admin/students_controller.rb
@@ -1,5 +1,7 @@
 module Admin
   class StudentsController < ApplicationController
+    include Carmen
+
     def index
       @nav = "Students"
       @students = Student.order(:last_name)
@@ -66,7 +68,7 @@ module Admin
       params.require(:student).permit(:first_name, :last_name,
         :email, :phone_number, :guardian_phone_number, :guardian_first_name,
         :guardian_last_name, :emergency_contact_first_name, :emergency_contact_last_name,
-        :emergency_contact_phone_number, :date_of_birth, volunteer_ids: [])
+        :emergency_contact_phone_number, :date_of_birth, :city, :state, volunteer_ids: [])
     end
   end
 end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -164,3 +164,13 @@ body.sb-sidenav-toggled #wrapper #sidebar-wrapper {
 .sort-asc {
   border-bottom: 8px solid #311B92;
 }
+
+.ss-main {
+  .ss-single-selected {
+    .placeholder {
+      cursor: pointer;
+      opacity: 1;
+      background-color: transparent;
+    }
+  }
+}

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -12,6 +12,7 @@ class Student < ApplicationRecord
   belongs_to :deactivator, class_name: "User", optional: true
 
   validates :first_name, :last_name, presence: true
+  validates :state, length: {minimum: 2, maximum: 2}, allow_blank: true
 
   enum status: {active: 0, inactive: 1}
 

--- a/app/views/admin/students/_form.html.erb
+++ b/app/views/admin/students/_form.html.erb
@@ -59,6 +59,22 @@
     </div>
   </div>
 
+  <div class="row pr-3 pb-4">
+    <div class="col-3">
+      <%= form.text_field :city, class: "form-control", placeholder: "City" %>
+    </div>
+
+    <div class="col-3">
+      <%= form.select(
+        :state,
+        Carmen::Country.coded("US").subregions.typed("state").map { |state| [state.name, state.code] },
+        { include_hidden: false, selected: @student.state, class: "form-control" },
+        { 'data-controller' => 'autocomplete-select',
+          'data-autocomplete-select-placeholder' => "Select State" }
+      ) %>
+    </div>
+  </div>
+
   <label class="gray-text mt-4 mb-1">ASSIGN VOLUNTEER</label>
   <div class="row pr-3 pb-4">
     <div class="col-6">

--- a/app/views/admin/students/_form.html.erb
+++ b/app/views/admin/students/_form.html.erb
@@ -68,7 +68,7 @@
       <%= form.select(
         :state,
         Carmen::Country.coded("US").subregions.typed("state").map { |state| [state.name, state.code] },
-        { include_hidden: false, selected: @student.state, class: "form-control" },
+        { include_hidden: false, selected: @student.state },
         { 'data-controller' => 'autocomplete-select',
           'data-autocomplete-select-placeholder' => "Select State" }
       ) %>
@@ -95,8 +95,9 @@
       <%= form.select(
         :staff_id,
         User.where(role: :admin).map { |staff| [staff.name, staff.id] },
-        { include_blank: "Select Staff", selected: @student.active_student_staff_assignment&.staff_id },
-        class: "form-select"
+        { include_hidden: false, selected: @student.active_student_staff_assignment&.staff_id },
+        { 'data-controller' => 'autocomplete-select',
+          'data-autocomplete-select-placeholder' => "Select Staff" }
       ) %>
     </div>
   </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,7 @@ require "action_mailbox/engine"
 require "action_text/engine"
 require "action_view/railtie"
 require "action_cable/engine"
+require "carmen"
 require "sprockets/railtie"
 require "rails/test_unit/railtie"
 

--- a/db/migrate/20211208155836_add_city_and_state_to_students.rb
+++ b/db/migrate/20211208155836_add_city_and_state_to_students.rb
@@ -1,0 +1,6 @@
+class AddCityAndStateToStudents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :students, :city, :string
+    add_column :students, :state, :string, limit: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_05_210424) do
+ActiveRecord::Schema.define(version: 2021_12_08_155836) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,6 +76,8 @@ ActiveRecord::Schema.define(version: 2021_12_05_210424) do
     t.string "guardian_last_name"
     t.string "emergency_contact_first_name"
     t.string "emergency_contact_last_name"
+    t.string "city"
+    t.string "state", limit: 2
     t.index ["deactivator_id"], name: "index_students_on_deactivator_id"
   end
 


### PR DESCRIPTION
Resolves #173 

### Description

Adds a single select typeahead input for US states, adding Carmen as a ruby dependency, and reusing slim-select . Also upgrades the staff contact select to a typeahead.

### Type of change

* New feature (non-breaking change which adds functionality)

### Screenshots

![Screen Shot 2021-12-08 at 11 50 54 AM](https://user-images.githubusercontent.com/12770108/145249289-cc3f8f88-859b-4e64-a09d-1b7c72659c36.png)

