### PR TITLE
Keep cleaning up views

### DIFF
--- a/app/controllers/admin/tickets_controller.rb
+++ b/app/controllers/admin/tickets_controller.rb
@@ -40,7 +40,7 @@ module Admin
     end
 
     def resolve
-      if ticket.close!(current_user, closer_notes: ticket_update_params[:closer_notes])
+      if ticket.close!(current_user, ticket_update_params[:closer_notes])
         redirect_to admin_tickets_path, notice: "The support ticket was successfully resolved."
       else
         flash[:alert] = "Could not resolve the support ticket. Please try again."

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -145,6 +145,10 @@ th {
     border-bottom: 8px solid $teal;
 }
 
+.nowrap {
+    white-space: nowrap;
+}
+
 
 ////////*   Text & Background Colors   *////////
 

--- a/app/models/support_ticket.rb
+++ b/app/models/support_ticket.rb
@@ -15,7 +15,9 @@ class SupportTicket < ApplicationRecord
   enum status: {active: 0, closed: 1}
   enum category: {survey_response: 0, admin: 1, contact_info: 2}
 
-  def close!(closer, closer_notes: nil)
+  delegate :student, to: :survey_response, allow_nil: true
+
+  def close!(closer, closer_notes)
     return false if closed?
 
     update!(status: :closed, closer: closer, closer_notes: closer_notes, closed_at: Time.current)
@@ -34,10 +36,10 @@ class SupportTicket < ApplicationRecord
   end
 
   def staff_contact_name
-    survey_response&.student&.active_student_staff_assignment&.staff&.name || "N/A"
+    student&.active_student_staff_assignment&.staff&.name || "N/A"
   end
 
   def student_name
-    survey_response&.student&.name || "N/A"
+    student&.name || "N/A"
   end
 end

--- a/app/views/admin/tickets/show.html.erb
+++ b/app/views/admin/tickets/show.html.erb
@@ -8,7 +8,7 @@
     </h2>
   </div>
 
-  <div class="pb-2">
+  <div>
     <div class="card shadow-sm">
       <div class="card-body">
         <div class="row">
@@ -34,7 +34,7 @@
   </div>
 
   <% if @ticket.closer.present? %>
-    <div class="pb-2">
+    <div class="pb-4">
       <div class="card shadow-sm">
         <div class="card-body">
           <div class="row">
@@ -56,7 +56,7 @@
     </div>
   <% end %>
 
-  <div class="pb-2">
+  <div class="pb-4">
     <div class="card shadow-sm">
       <div class="card-body">
         <label class="text-dark-gray">DESCRIPTION</label>
@@ -74,11 +74,10 @@
         </div>
       </div>
     </div>
-  <% end %>
+  <% else %>
 
-  <% if @ticket.closer.blank? %>
     <%= form_with(model: @ticket, url: resolve_admin_ticket_url, method: :post) do |f| %>
-      <label class="text-dark-gray mt-4 mb-1"></label>
+      <label class="text-dark-gray mt-4 mb-3">RESOLUTION DESCRIPTION</label>
       <div class="row pr-3 pb-2">
         <div>
           <%= f.text_area :closer_notes, class: "form-control", placeholder: "Describe how support request was resolved" %>

--- a/app/views/admin/volunteers/_volunteers_table.html.erb
+++ b/app/views/admin/volunteers/_volunteers_table.html.erb
@@ -71,7 +71,6 @@
           <% else %>
             <%= link_to "Activate", activate_admin_volunteer_path(volunteer), method: :patch, data: { confirm: "Are you sure?" } %>
           <% end %>
-
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/volunteers/_volunteers_table.html.erb
+++ b/app/views/admin/volunteers/_volunteers_table.html.erb
@@ -47,10 +47,10 @@
         <td>
           <%= volunteer.last_name %>
         </td>
-        <td>
+        <td class="nowrap">
           <%= volunteer.email %>
         </td>
-        <td>
+        <td class="nowrap">
           <%= format_phone_number(volunteer.phone_number) %>
         </td>
         <td>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p>Welcome <%= @email %>!</p>
+
+<p>You can confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @email %>!</p>
+
+<% if @resource.try(:unconfirmed_email?) %>
+  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+<% else %>
+  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+<% end %>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,0 +1,3 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>We're contacting you to notify you that your password has been changed.</p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please ignore this email.</p>
+<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+
+<p>Click the link below to unlock your account:</p>
+
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,0 +1,25 @@
+<h2>Change your password</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= f.hidden_field :reset_password_token %>
+
+  <div class="field">
+    <%= f.label :password, "New password" %><br />
+    <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+    <% end %>
+    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation, "Confirm new password" %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Change my password" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Forgot your password?</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Send me reset password instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,0 +1,50 @@
+<div class="container">
+  <%= link_to "Back", :back %>
+
+  <h3>Edit Your Login</h3>
+  <br />
+
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+
+    <div class="row pr-3 pb-4">
+      <div class="col-6">
+        <%= f.email_field :email, class: "form-control py-2", placeholder: "Email", autofocus: true, autocomplete: "email" %>
+      </div>
+    </div>
+
+    <div class="row pr-3 pb-4">
+      <div class="col-6">
+        <div class="mb-2">
+          <%= f.label :new_password %> <i>(leave blank if you don't want to change it)</i>
+        </div>
+        <%= f.password_field :password, class: "form-control py-2", placeholder: "New Password", autocomplete: "new-password" %>
+      </div>
+    </div>
+
+    <div class="row pr-3 pb-4">
+      <div class="col-6">
+        <%= f.password_field :password_confirmation, class: "form-control py-2", placeholder: "New Password Confirmation", autocomplete: "new-password" %>
+      </div>
+    </div>
+
+    <div class="row pr-3 pb-4">
+      <div class="col-6">
+        <div class="mb-2">
+          <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i>
+        </div>
+        <%= f.password_field :current_password, class: "form-control py-2", placeholder: "Current Password", autocomplete: "current-password" %>
+      </div>
+    </div>
+
+    <div class="row pr-3 pb-4 mt-4">
+      <div class="col-2">
+        <%= link_to 'CANCEL', :back, class: 'btn btn-purple-secondary'%>
+      </div>
+
+      <div class="col-2">
+        <%= f.submit 'SAVE', class: 'btn btn-purple-primary' %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,29 @@
+<h2>Sign up</h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %>
+    <% if @minimum_password_length %>
+    <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <% end %><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Sign up" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,26 @@
+<h2>Log in</h2>
+
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %><br />
+    <%= f.password_field :password, autocomplete: "current-password" %>
+  </div>
+
+  <% if devise_mapping.rememberable? %>
+    <div class="field">
+      <%= f.check_box :remember_me %>
+      <%= f.label :remember_me %>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= f.submit "Log in" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,33 @@
-<h2>Log in</h2>
+<div class="container">
+  <h2>Log in</h2>
+  <br />
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+    <div class="row pr-3 pb-4">
+      <div class="col-6">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, class: "form-control py-2", placeholder: "Email", autofocus: true, autocomplete: "email" %>
+      </div>
+    </div>
 
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
+    <div class="row pr-3 pb-4">
+      <div class="col-6">
+        <%= f.label :password %><br />
+        <%= f.password_field :password, class: "form-control py-2", placeholder: "Password", autocomplete: "current-password" %>
+      </div>
+    </div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+    <% if devise_mapping.rememberable? %>
+      <div class="field">
+        <%= f.check_box :remember_me %>
+        <%= f.label :remember_me %>
+      </div>
+    <% end %>
+
+    <div class="row pr-3 pb-4 mt-4">
+      <div class="col-2">
+        <%= f.submit "LOG IN", class: 'btn btn-purple-primary' %>
+      </div>
     </div>
   <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,0 +1,15 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation">
+    <h2>
+      <%= I18n.t("errors.messages.not_saved",
+                 count: resource.errors.count,
+                 resource: resource.class.model_name.human.downcase)
+       %>
+    </h2>
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,0 +1,25 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Log in", new_session_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post %><br />
+  <% end %>
+<% end %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend unlock instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend unlock instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -248,7 +248,7 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  # config.scoped_views = false
+  config.scoped_views = true
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).

--- a/spec/models/support_ticket_spec.rb
+++ b/spec/models/support_ticket_spec.rb
@@ -20,28 +20,35 @@ RSpec.describe SupportTicket, type: :model do
     it { is_expected.to define_enum_for(:category).with_values(survey_response: 0, admin: 1, contact_info: 2) }
   end
 
-  context "#close!(user)" do
+  context "#close!(user, notes)" do
     let(:user) { create(:user) }
     subject(:support_ticket) { create(:support_ticket) }
 
     it "returns false if the ticket is already closed" do
-      expect(build(:support_ticket, status: :closed).close!(user)).to be_falsey
+      expect(build(:support_ticket, status: :closed).close!(user, nil)).to be_falsey
     end
 
     it "updates ticket's status to closed" do
-      support_ticket.close!(user)
+      support_ticket.close!(user, "Done")
       expect(support_ticket).to be_closed
     end
 
     it "updates ticket's closer" do
-      support_ticket.close!(user)
+      support_ticket.close!(user, "Done")
       expect(support_ticket.closer).to eq user
     end
 
     it "updates ticket's closed_at" do
       freeze_time do
-        support_ticket.close!(user)
+        support_ticket.close!(user, "Done")
         expect(support_ticket.closed_at).to eq Time.current
+      end
+    end
+
+    it "updates ticket's closer_notes" do
+      freeze_time do
+        support_ticket.close!(user, "Done")
+        expect(support_ticket.closer_notes).to eq "Done"
       end
     end
   end

--- a/spec/system/organizations/edit_form_spec.rb
+++ b/spec/system/organizations/edit_form_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "the edit organization form", type: :feature do
   it "updates the name of an organization" do
-    stub_login
+    login
     organization = create(:organization, name: "Kurstyn's Dog and Baby Club")
 
     visit "/admin/organizations/#{organization.id}/edit"
@@ -17,13 +17,13 @@ describe "the edit organization form", type: :feature do
 
   private
 
-  def stub_login
+  def login
     admin = create(:admin)
 
     visit new_user_session_path
 
     fill_in "Email", with: admin.email
     fill_in "Password", with: admin.password
-    click_button "Log in"
+    click_button "LOG IN"
   end
 end

--- a/spec/system/users/sessions/new_spec.rb
+++ b/spec/system/users/sessions/new_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "sessions#new", type: :system do
 
       fill_in "Email", with: volunteer.email
       fill_in "Password", with: volunteer.password
-      click_button "Log in"
+      click_button "LOG IN"
 
       expect(page).to have_text "Your password is expired. Please renew your password."
     end
@@ -24,7 +24,7 @@ RSpec.describe "sessions#new", type: :system do
 
       fill_in "Email", with: volunteer.email
       fill_in "Password", with: volunteer.password
-      click_button "Log in"
+      click_button "LOG IN"
 
       expect(page).to have_text "Signed in successfully."
       expect(page).to have_selector("h1", text: "Volunteer Home")
@@ -39,7 +39,7 @@ RSpec.describe "sessions#new", type: :system do
 
       fill_in "Email", with: admin.email
       fill_in "Password", with: admin.password
-      click_button "Log in"
+      click_button "LOG IN"
 
       expect(page).to have_text "Signed in successfully."
       expect(page).to have_selector("h1", text: "Home")


### PR DESCRIPTION
### Description

- Display of Phones & Emails should not wrap
- Add missing label and fix spacing on Support Ticket form
- Do not let closer notes be passed optionally
- Add Devise views and style the login and User Edit forms

### Type of change

* New feature (non-breaking change which adds functionality)

### Screenshots

<img width="729" alt="Screen Shot 2021-12-25 at 8 48 22 AM" src="https://user-images.githubusercontent.com/12770108/147386413-38207fa0-fabb-48e4-83c9-aab1a418573a.png">

<img width="755" alt="Screen Shot 2021-12-25 at 8 48 38 AM" src="https://user-images.githubusercontent.com/12770108/147386406-db7477d5-23da-48b5-9628-5a3f08c957d6.png">

<img width="1253" alt="Screen Shot 2021-12-25 at 8 48 48 AM" src="https://user-images.githubusercontent.com/12770108/147386408-5e6579eb-867c-4d07-ab93-3a43a11c4b0e.png">

